### PR TITLE
Mac OS X fix: no ALUT framework

### DIFF
--- a/ALUT.cabal
+++ b/ALUT.cabal
@@ -59,7 +59,7 @@ library
     extra-libraries: alut
   else
     cpp-options: "-DCALLCONV=ccall"
-    if os(darwin) || os(ios)
+    if os(ios)
       frameworks: ALUT
     else
       extra-libraries: alut


### PR DESCRIPTION
Currently, when using ALUT in a project on Mac OS X Yosemite (clang), linking fails because no framework is found:

```
Linking dist/build/music/music ...
ld: framework not found ALUT
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

This pull request fixes this by not using an alut framework but working with extra-libraries.
Prerequisite to it working is installing freealut (brew install freealut with homebrew), since that's what ultimately used in the linked executable.
